### PR TITLE
Note new default limits

### DIFF
--- a/_articles/using-the-api.md
+++ b/_articles/using-the-api.md
@@ -23,7 +23,7 @@ All requests return a [GeoJSON](https://geojson.org/) response containing an arr
 You may get multiple Parcel Records per response. This depends on how you search for parcels via our Parcel API. Address matching, parcel number, owner name matching, parcels in a radius are all example of Parcel API requests that will likely return multiple Parcel Records in each response.
 
 #### Limit Parcel Records returned
-Each Parcel API request can return one or more Parcel Records. Any Parcel API request that can return multiple Parcel Records supports the optional `limit=` parameter that will allow you to limit the number of return Parcel Records.
+Each Parcel API request can return one or more Parcel Records. Any Parcel API request that can return multiple Parcel Records supports the optional `limit=` parameter that will allow you to limit the number of return Parcel Records. The default limit is 20 Parcel Records. The maximum limit is 1,000 Parcel Records.
 
 #### API Request Rates
 


### PR DESCRIPTION
@Blake-Loveland, Yesterday I added a default limit to queries as well as a maximum limit: https://github.com/loveland/wdwot/pull/3311 

My rationale was: 

- It's not obvious that the default API search limits were fairly high (100 parcels), and we are now doing pay-per-parcel pricing, so this felt like it would reduce surprises
- Trial API customers quickly use up their trial quota
- Responses with a limit complete faster

I should asked you to review it before it went out, and I'm happy to roll it back or adjust it. But in any case I wanted to makes sure it was documented. 